### PR TITLE
Add function index offset support in Assembler for CALLF/FUNCREF

### DIFF
--- a/cs/App.cs
+++ b/cs/App.cs
@@ -142,6 +142,7 @@ public struct App {
 
 		if (debugMode) IOHelper.Print(StringUtils.Format("Assembling {0} lines...", lines.Count));
 		Assembler assembler = new Assembler();
+		assembler.SetFunctionIndexOffset(Intrinsic.Count());
 
 		// Assemble the code
 		assembler.Assemble(lines);

--- a/cs/Assembler.cs
+++ b/cs/Assembler.cs
@@ -22,8 +22,13 @@ public class Assembler {
 	// Multiple functions support
 	public List<FuncDef> Functions = new List<FuncDef>(); // all functions
 	public FuncDef Current = new FuncDef(); // function we are currently building
+	public Int32 FunctionIndexOffset = 0; // added to assembled CALLF/FUNCREF targets
 	private List<String> _labelNames = new List<String>(); // label names within current function
 	private List<Int32> _labelAddresses = new List<Int32>(); // corresponding instruction addresses within current function
+
+	public void SetFunctionIndexOffset(Int32 offset) {
+		FunctionIndexOffset = offset;
+	}
 	
 	// Error handling state
 	public Boolean HasError { get; private set; }
@@ -282,7 +287,17 @@ public class Assembler {
 			}
 			Byte dest = ParseRegister(parts[1]);
 			Current.ReserveRegister(dest);
-			Int16 funcIdx = (Int16)FindFunctionIndex(parts[2]);
+			Int32 localIdx = FindFunctionIndex(parts[2]);
+			if (localIdx < 0) {
+				Error(StringUtils.Format("Unknown function: '{0}'", parts[2]));
+				return 0;
+			}
+			Int32 resolvedIdx = localIdx + FunctionIndexOffset;
+			if (resolvedIdx < Int16.MinValue || resolvedIdx > Int16.MaxValue) {
+				Error(StringUtils.Format("Function index out of range for FUNCREF: {0}", resolvedIdx));
+				return 0;
+			}
+			Int16 funcIdx = (Int16)resolvedIdx;
 			instruction = BytecodeUtil.INS_AB(Opcode.FUNCREF_iA_iBC, dest, funcIdx);
 
 		} else if (mnemonic == "ASSIGN") {
@@ -555,11 +570,17 @@ public class Assembler {
 		} else if (mnemonic == "CALLF") {
 			if (parts.Count != 3) { Error("Syntax error"); return 0; }
 			Byte reserveRegs = (Byte)ParseInt16(parts[1]);	// ToDo: check range before typecast
-			Int16 funcIdx = (Int16)FindFunctionIndex(parts[2]);
-			if (funcIdx < 0) {
+			Int32 localIdx = FindFunctionIndex(parts[2]);
+			if (localIdx < 0) {
 				Error(StringUtils.Format("Unknown function: '{0}'", parts[2]));
 				return 0;
 			}
+			Int32 resolvedIdx = localIdx + FunctionIndexOffset;
+			if (resolvedIdx < Int16.MinValue || resolvedIdx > Int16.MaxValue) {
+				Error(StringUtils.Format("Function index out of range for CALLF: {0}", resolvedIdx));
+				return 0;
+			}
+			Int16 funcIdx = (Int16)resolvedIdx;
 			instruction = BytecodeUtil.INS_AB(Opcode.CALLF_iA_iBC, reserveRegs, funcIdx);
 
 		} else if (mnemonic == "CALLFN") {

--- a/cs/VM.cs
+++ b/cs/VM.cs
@@ -1905,5 +1905,3 @@ public class VM {
 }
 
 }
-
-//*** END CS_ONLY ***

--- a/generated/App.g.cpp
+++ b/generated/App.g.cpp
@@ -135,6 +135,7 @@ List<FuncDef> App::AssembleFile(String filePath) {
 
 	if (debugMode) IOHelper::Print(StringUtils::Format("Assembling {0} lines...", lines.Count()));
 	Assembler assembler =  Assembler::New();
+	assembler.SetFunctionIndexOffset(Intrinsic::Count());
 
 	// Assemble the code
 	assembler.Assemble(lines);

--- a/generated/Assembler.g.cpp
+++ b/generated/Assembler.g.cpp
@@ -12,6 +12,9 @@ namespace MiniScript {
 
 AssemblerStorage::AssemblerStorage() {
 }
+void AssemblerStorage::SetFunctionIndexOffset(Int32 offset) {
+	FunctionIndexOffset = offset;
+}
 Int32 AssemblerStorage::FindFunctionIndex(String name) {
 	for (Int32 i = 0; i < Functions.Count(); i++) {
 		if (Functions[i].Name() == name) return i;
@@ -263,7 +266,19 @@ UInt32 AssemblerStorage::AddLine(String line,Int32 lineNumber) {
 		}
 		Byte dest = ParseRegister(parts[1]);
 		Current.ReserveRegister(dest);
-		Int16 funcIdx = (Int16)FindFunctionIndex(parts[2]);
+		Int32 localIdx = FindFunctionIndex(parts[2]);
+		if (localIdx < 0) {
+			Error(StringUtils::Format("Unknown function: '{0}'", parts[2]));
+			GC_POP_SCOPE();
+			return 0;
+		}
+		Int32 resolvedIdx = localIdx + FunctionIndexOffset;
+		if (resolvedIdx < Int16MinValue || resolvedIdx > Int16MaxValue) {
+			Error(StringUtils::Format("Function index out of range for FUNCREF: {0}", resolvedIdx));
+			GC_POP_SCOPE();
+			return 0;
+		}
+		Int16 funcIdx = (Int16)resolvedIdx;
 		instruction = BytecodeUtil::INS_AB(Opcode::FUNCREF_iA_iBC, dest, funcIdx);
 
 	} else if (mnemonic == "ASSIGN") {
@@ -654,12 +669,19 @@ UInt32 AssemblerStorage::AddLine(String line,Int32 lineNumber) {
 			return 0; }
 		}
 		Byte reserveRegs = (Byte)ParseInt16(parts[1]);	// ToDo: check range before typecast
-		Int16 funcIdx = (Int16)FindFunctionIndex(parts[2]);
-		if (funcIdx < 0) {
+		Int32 localIdx = FindFunctionIndex(parts[2]);
+		if (localIdx < 0) {
 			Error(StringUtils::Format("Unknown function: '{0}'", parts[2]));
 			GC_POP_SCOPE();
 			return 0;
 		}
+		Int32 resolvedIdx = localIdx + FunctionIndexOffset;
+		if (resolvedIdx < Int16MinValue || resolvedIdx > Int16MaxValue) {
+			Error(StringUtils::Format("Function index out of range for CALLF: {0}", resolvedIdx));
+			GC_POP_SCOPE();
+			return 0;
+		}
+		Int16 funcIdx = (Int16)resolvedIdx;
 		instruction = BytecodeUtil::INS_AB(Opcode::CALLF_iA_iBC, reserveRegs, funcIdx);
 
 	} else if (mnemonic == "CALLFN") {

--- a/generated/Assembler.g.h
+++ b/generated/Assembler.g.h
@@ -19,14 +19,17 @@ class AssemblerStorage : public std::enable_shared_from_this<AssemblerStorage> {
 	public: AssemblerStorage();
 	public: List<FuncDef> Functions = List<FuncDef>::New(); // all functions
 	public: FuncDef Current = FuncDef::New(); // function we are currently building
+	public: Int32 FunctionIndexOffset = 0; // added to assembled CALLF/FUNCREF targets
 	private: List<String> _labelNames = List<String>::New(); // label names within current function
 	private: List<Int32> _labelAddresses = List<Int32>::New(); // corresponding instruction addresses within current function
+
+	// Multiple functions support
+
+	public: void SetFunctionIndexOffset(Int32 offset);
 	public: Boolean HasError;
 	public: String ErrorMessage;
 	public: Int32 CurrentLineNumber;
 	public: String CurrentLine;
-
-	// Multiple functions support
 	
 	// Error handling state
 
@@ -152,10 +155,16 @@ struct Assembler {
 	public: void set_Functions(List<FuncDef> _v); // all functions
 	public: FuncDef Current(); // function we are currently building
 	public: void set_Current(FuncDef _v); // function we are currently building
+	public: Int32 FunctionIndexOffset(); // added to assembled CALLF/FUNCREF targets
+	public: void set_FunctionIndexOffset(Int32 _v); // added to assembled CALLF/FUNCREF targets
 	private: List<String> _labelNames(); // label names within current function
 	private: void set__labelNames(List<String> _v); // label names within current function
 	private: List<Int32> _labelAddresses(); // corresponding instruction addresses within current function
 	private: void set__labelAddresses(List<Int32> _v); // corresponding instruction addresses within current function
+
+	// Multiple functions support
+
+	public: inline void SetFunctionIndexOffset(Int32 offset);
 	public: Boolean HasError();
 	public: void set_HasError(Boolean _v);
 	public: String ErrorMessage();
@@ -164,8 +173,6 @@ struct Assembler {
 	public: void set_CurrentLineNumber(Int32 _v);
 	public: String CurrentLine();
 	public: void set_CurrentLine(String _v);
-
-	// Multiple functions support
 	
 	// Error handling state
 
@@ -280,10 +287,13 @@ inline List<FuncDef> Assembler::Functions() { return get()->Functions; } // all 
 inline void Assembler::set_Functions(List<FuncDef> _v) { get()->Functions = _v; } // all functions
 inline FuncDef Assembler::Current() { return get()->Current; } // function we are currently building
 inline void Assembler::set_Current(FuncDef _v) { get()->Current = _v; } // function we are currently building
+inline Int32 Assembler::FunctionIndexOffset() { return get()->FunctionIndexOffset; } // added to assembled CALLF/FUNCREF targets
+inline void Assembler::set_FunctionIndexOffset(Int32 _v) { get()->FunctionIndexOffset = _v; } // added to assembled CALLF/FUNCREF targets
 inline List<String> Assembler::_labelNames() { return get()->_labelNames; } // label names within current function
 inline void Assembler::set__labelNames(List<String> _v) { get()->_labelNames = _v; } // label names within current function
 inline List<Int32> Assembler::_labelAddresses() { return get()->_labelAddresses; } // corresponding instruction addresses within current function
 inline void Assembler::set__labelAddresses(List<Int32> _v) { get()->_labelAddresses = _v; } // corresponding instruction addresses within current function
+inline void Assembler::SetFunctionIndexOffset(Int32 offset) { return get()->SetFunctionIndexOffset(offset); }
 inline Boolean Assembler::HasError() { return get()->HasError; }
 inline void Assembler::set_HasError(Boolean _v) { get()->HasError = _v; }
 inline String Assembler::ErrorMessage() { return get()->ErrorMessage; }

--- a/generated/VM.g.h
+++ b/generated/VM.g.h
@@ -498,4 +498,3 @@ inline Value VM::LookupParamByName(String varName) { return get()->LookupParamBy
 inline Value VM::LookupVariable(Value varName) { return get()->LookupVariable(varName); }
 
 } // end of namespace MiniScript
-


### PR DESCRIPTION
This was a Copilot fix.  
Fixed. The transpile issue is resolved, and I revalidated the workflow end-to-end.

What I changed:
1. Removed the stray unmatched CS-only marker at the end of VM.cs, which was causing the transpiler state error.
2. Made the assembler offset path transpiler-safe in Assembler.cs:
- Used a plain field for FunctionIndexOffset at Assembler.cs.
- Added an explicit setter method at Assembler.cs.
- Kept CALLF/FUNCREF index offset + range/unknown checks at Assembler.cs and Assembler.cs.
3. Updated assembly path to use the setter in App.cs.

Why the setter change was needed:
- Direct property assignment transpiled to invalid C++ in generated output (assembler::FunctionIndexOffset ...).
- Explicit method call transpiles correctly.

Retest results:
1. Transpile:
- build.sh transpile
- Passed successfully.

2. C++ workflow:
- build.sh cpp on
- build/cpp/miniscript2 recur_fib.msa
- Result in r0: 3524578

3. C# workflow:
- build.sh cs
- dotnet miniscript2.dll recur_fib.msa
- Result in r0: 3524578

