### PR TITLE
include cstdint and change C standard to GNU99

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.15)
 project(miniscript2 LANGUAGES C CXX)
 
 set(CMAKE_C_STANDARD 99)
+set(CMAKE_C_EXTENSIONS ON)   # gnu++11, needed for POSIX extensions
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_EXTENSIONS ON)   # gnu++11, needed for computed-goto
 

--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -21,11 +21,11 @@ else
 endif
 
 CXXFLAGS = -std=gnu++11 -Wall -Wextra $(OPT_FLAGS) -Icore -I$(GENDIR) -I. $(GOTO_FLAG) $(EDITLINE_DEFINE) -MMD -MP
-CFLAGS = -std=c99 -Wall -Wextra $(OPT_FLAGS) -Icore $(GOTO_FLAG) -MMD -MP
+CFLAGS = -std=gnu99 -Wall -Wextra $(OPT_FLAGS) -Icore $(GOTO_FLAG) -MMD -MP
 
 # AddressSanitizer flags for debugging
 ASAN_CXXFLAGS = -std=gnu++11 -Wall -Wextra -O0 -g -fsanitize=address -Icore -I$(GENDIR) -I. $(GOTO_FLAG) $(EDITLINE_DEFINE) -MMD -MP
-ASAN_CFLAGS = -std=c99 -Wall -Wextra -O0 -g -fsanitize=address -Icore $(GOTO_FLAG) -MMD -MP
+ASAN_CFLAGS = -std=gnu99 -Wall -Wextra -O0 -g -fsanitize=address -Icore $(GOTO_FLAG) -MMD -MP
 ASAN_LDFLAGS = -fsanitize=address
 COREDIR = core
 EDITLINEDIR = editline
@@ -135,7 +135,7 @@ $(OBJDIR)/gen_%.o: $(GENDIR)/%.g.cpp | $(OBJDIR)
 
 # editline C object files (Unix/macOS only)
 $(OBJDIR)/editline_%.o: $(EDITLINEDIR)/%.c | $(OBJDIR)
-	$(CC) -std=c99 -Wall $(OPT_FLAGS) $(EDITLINE_CFLAGS) -c $< -o $@
+	$(CC) -std=gnu99 -Wall $(OPT_FLAGS) $(EDITLINE_CFLAGS) -c $< -o $@
 
 # ASAN target
 $(ASAN_TARGET): $(ASAN_OBJECTS) | $(BUILDDIR)
@@ -155,7 +155,7 @@ $(ASAN_OBJDIR)/gen_%.o: $(GENDIR)/%.g.cpp | $(ASAN_OBJDIR)
 
 # ASAN editline C object files (Unix/macOS only)
 $(ASAN_OBJDIR)/editline_%.o: $(EDITLINEDIR)/%.c | $(ASAN_OBJDIR)
-	$(CC) -std=c99 -Wall -O0 -g -fsanitize=address $(EDITLINE_CFLAGS) -c $< -o $@
+	$(CC) -std=gnu99 -Wall -O0 -g -fsanitize=address $(EDITLINE_CFLAGS) -c $< -o $@
 
 $(ASAN_OBJDIR):
 	mkdir -p $(ASAN_OBJDIR)

--- a/cpp/core/CS_List.h
+++ b/cpp/core/CS_List.h
@@ -3,6 +3,7 @@
 // as well as possible.  Memory management is done via std::shared_ptr and std::vector.
 
 #pragma once
+#include <cstdint>
 #include <memory>
 #include <vector>
 #include <initializer_list>


### PR DESCRIPTION
### info: 
gcc version 16.1.1 on arch linux (the newer more restictive compiler required these changes to avoid build errors)
### changes:
- cstdint included inside CS_List.h because of uint8_t usage
- C standard changed from C99 to GNU99 because of usage of GNU/POSIX extensions in C files(such as strdup)